### PR TITLE
test_ssp: Perform role switch only when required

### DIFF
--- a/cases/security_test.py
+++ b/cases/security_test.py
@@ -194,7 +194,7 @@ class SecurityTest(base_test.BaseTestClass):  # type: ignore[misc]
                         self.ref.log.info(
                             f"Role switch to: {'`CENTRAL`' if role == HCI_CENTRAL_ROLE else '`PERIPHERAL`'}"
                         )
-                    await ref_dut_raw.switch_role(role)
+                        await ref_dut_raw.switch_role(role)
 
             # Pairing.
             if pair == 'incoming_pairing':


### PR DESCRIPTION
Role switch fails with an exception if the requested role
is the same as the currently held role (as per specification)
