### PR TITLE
security_test: Disable SSP tests for android pairing against central ref

### DIFF
--- a/cases/security_test.py
+++ b/cases/security_test.py
@@ -135,6 +135,12 @@ class SecurityTest(base_test.BaseTestClass):  # type: ignore[misc]
                 + 'Android does not seems to react correctly against pairing reject from KEYBOARD_ONLY devices.'
             )
 
+        if self.dut.name == 'android' and pair == 'outgoing_pairing' and ref_role == 'against_central':
+            raise signals.TestSkip(
+                'TODO: Fix PandoraSecurity server for android:\n'
+                + 'report the encryption state the with the bonding state'
+            )
+
         if isinstance(self.ref, BumblePandoraDevice) and ref_io_capability == 'against_default_io_cap':
             raise signals.TestSkip('Skip default IO cap for Bumble REF.')
 
@@ -232,7 +238,6 @@ class SecurityTest(base_test.BaseTestClass):  # type: ignore[misc]
 
             dut_ev_answer, ref_ev_answer = None, None
             if not connect_and_pair_task.done():
-
                 dut_ev = await asyncio.wait_for(dut_pairing_fut, timeout=15.0)
                 self.dut.log.info(f'DUT pairing event: {dut_ev.method_variant()}')
 
@@ -318,7 +323,6 @@ class SecurityTest(base_test.BaseTestClass):  # type: ignore[misc]
                 connect_and_pair_task.cancel()
 
         finally:
-
             try:
                 (secure, wait_security) = await asyncio.wait_for(connect_and_pair_task, 15.0)
                 logging.info(f'Pairing result: {secure.result_variant()}/{wait_security.result_variant()}')


### PR DESCRIPTION
Android is attempting to perform a role switch in this case,
which is rejected and causes timing issues for reporting
the final encryption state of the link.
The tests are currently not passing on emulator.
