### PR TITLE
move reset from setup to teardown

### DIFF
--- a/cases/host_test.py
+++ b/cases/host_test.py
@@ -42,7 +42,8 @@ class HostTest(base_test.BaseTestClass):  # type: ignore[misc]
     dut: PandoraDevice
     ref: PandoraDevice
 
-    def setup_class(self) -> None:
+    @avatar.asynchronous
+    async def setup_class(self) -> None:
         self.devices = PandoraDevices(self)
         self.dut, self.ref, *_ = self.devices
 
@@ -51,13 +52,16 @@ class HostTest(base_test.BaseTestClass):  # type: ignore[misc]
             if isinstance(device, BumblePandoraDevice):
                 device.config.setdefault('classic_enabled', True)
 
+        await asyncio.gather(self.dut.reset(), self.ref.reset())
+
     def teardown_class(self) -> None:
         if self.devices:
             self.devices.stop_all()
 
     @avatar.asynchronous
-    async def setup_test(self) -> None:  # pytype: disable=wrong-arg-types
-        await asyncio.gather(self.dut.reset(), self.ref.reset())
+    async def teardown_test(self) -> None:
+        if self.results.is_test_executed(self.current_test_info.name):  # type: ignore
+            await asyncio.gather(self.dut.reset(), self.ref.reset())
 
     @avatar.parameterized(
         (DISCOVERABLE_LIMITED,),

--- a/cases/le_host_test.py
+++ b/cases/le_host_test.py
@@ -51,7 +51,8 @@ class LeHostTest(base_test.BaseTestClass):  # type: ignore[misc]
     dut: PandoraDevice
     ref: PandoraDevice
 
-    def setup_class(self) -> None:
+    @avatar.asynchronous
+    async def setup_class(self) -> None:
         self.devices = PandoraDevices(self)
         self.dut, self.ref, *_ = self.devices
 
@@ -60,13 +61,16 @@ class LeHostTest(base_test.BaseTestClass):  # type: ignore[misc]
             if isinstance(device, BumblePandoraDevice):
                 device.config.setdefault('classic_enabled', True)
 
+        await asyncio.gather(self.dut.reset(), self.ref.reset())
+
     def teardown_class(self) -> None:
         if self.devices:
             self.devices.stop_all()
 
     @avatar.asynchronous
-    async def setup_test(self) -> None:  # pytype: disable=wrong-arg-types
-        await asyncio.gather(self.dut.reset(), self.ref.reset())
+    async def teardown_test(self) -> None:
+        if self.results.is_test_executed(self.current_test_info.name):  # type: ignore
+            await asyncio.gather(self.dut.reset(), self.ref.reset())
 
     @avatar.parameterized(
         *itertools.product(

--- a/cases/security_test.py
+++ b/cases/security_test.py
@@ -65,6 +65,11 @@ class SecurityTest(base_test.BaseTestClass):  # type: ignore[misc]
         if self.devices:
             self.devices.stop_all()
 
+    @avatar.asynchronous
+    async def teardown_test(self) -> None:
+        if self.results.is_test_executed(self.current_test_info.name):  # type: ignore
+            await asyncio.gather(self.dut.reset(), self.ref.reset())
+
     @avatar.parameterized(
         *itertools.product(
             ('outgoing_connection', 'incoming_connection'),
@@ -141,9 +146,6 @@ class SecurityTest(base_test.BaseTestClass):  # type: ignore[misc]
 
         if not isinstance(self.ref, BumblePandoraDevice) and ref_io_capability != 'against_default_io_cap':
             raise signals.TestSkip('Unable to override IO capability on non Bumble device.')
-
-        # Factory reset both DUT and REF devices.
-        await asyncio.gather(self.dut.reset(), self.ref.reset())
 
         # Override REF IO capability if supported.
         if isinstance(self.ref, BumblePandoraDevice):


### PR DESCRIPTION
The reset is currently being done in the setup_test
hence it is executed for each tests even if the test is skipped.
Doing the reset on the teardown let us skip the reset when it is
not desired such as after a skipped test.

This reduce considerably the overall time for the tests execution.
