### PR TITLE
build: relax dependencies requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "bt-test-interfaces",
-    "bumble==0.0.170",
+    "bt-test-interfaces>=0.0.4",
+    "bumble>=0.0.176",
     "protobuf==4.24.2",
     "grpcio==1.57",
     "mobly==1.12.2",
@@ -25,7 +25,7 @@ avatar = "avatar:main"
 
 [project.optional-dependencies]
 dev = [
-    "rootcanal==1.3.0",
+    "rootcanal>=1.3.0",
     "grpcio-tools>=1.57",
     "pyright==1.1.298",
     "mypy==1.5.1",


### PR DESCRIPTION
All three packages `bt-test-interfaces`, `bumble` and `rootcanal` run the Avatar test suite on their respective CI.