### PR TITLE
cases: reset devices one by one

### DIFF
--- a/avatar/cases/host_test.py
+++ b/avatar/cases/host_test.py
@@ -59,7 +59,10 @@ class HostTest(base_test.BaseTestClass):  # type: ignore[misc]
 
     @avatar.asynchronous
     async def setup_test(self) -> None:  # pytype: disable=wrong-arg-types
-        await asyncio.gather(self.dut.reset(), self.ref.reset())
+        # NOTE: this used to be performed in parallel but can lead to flakiness
+        # (eg. the DUT has re-connect logics and REF reset too fast).
+        await self.dut.reset()
+        await self.ref.reset()
 
     @avatar.parameterized(
         (DISCOVERABLE_LIMITED,),

--- a/avatar/cases/le_host_test.py
+++ b/avatar/cases/le_host_test.py
@@ -74,7 +74,10 @@ class LeHostTest(base_test.BaseTestClass):  # type: ignore[misc]
 
     @avatar.asynchronous
     async def setup_test(self) -> None:  # pytype: disable=wrong-arg-types
-        await asyncio.gather(self.dut.reset(), self.ref.reset())
+        # NOTE: this used to be performed in parallel but can lead to flakiness
+        # (eg. the DUT has re-connect logics and REF reset too fast).
+        await self.dut.reset()
+        await self.ref.reset()
 
     @avatar.parameterized(
         *itertools.product(

--- a/avatar/cases/le_security_test.py
+++ b/avatar/cases/le_security_test.py
@@ -152,7 +152,10 @@ class LeSecurityTest(base_test.BaseTestClass):  # type: ignore[misc]
             raise signals.TestSkip('CTKD requires Security Level 4')
 
         # Factory reset both DUT and REF devices.
-        await asyncio.gather(self.dut.reset(), self.ref.reset())
+        # NOTE: this used to be performed in parallel but can lead to flakiness
+        # (eg. the DUT has re-connect logics and REF reset too fast).
+        await self.dut.reset()
+        await self.ref.reset()
 
         # Override REF IO capability if supported.
         if isinstance(self.ref, BumblePandoraDevice):

--- a/avatar/cases/security_test.py
+++ b/avatar/cases/security_test.py
@@ -200,7 +200,10 @@ class SecurityTest(base_test.BaseTestClass):  # type: ignore[misc]
             raise signals.TestSkip('CTKD cases must be conducted under Security Level 4')
 
         # Factory reset both DUT and REF devices.
-        await asyncio.gather(self.dut.reset(), self.ref.reset())
+        # NOTE: this used to be performed in parallel but can lead to flakiness
+        # (eg. the DUT has re-connect logics and REF reset too fast).
+        await self.dut.reset()
+        await self.ref.reset()
 
         # Override REF IO capability if supported.
         if isinstance(self.ref, BumblePandoraDevice):


### PR DESCRIPTION
Reseting devices in parallel can lead to flakiness (eg. the DUT has re-connect logics and REF reset too fast).